### PR TITLE
增加页面title显示当前项目的名称，同时打开多个项目时方便定位页面

### DIFF
--- a/Application/Home/View/Common/header.html
+++ b/Application/Home/View/Common/header.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>ShowDoc</title>
+    <title>{$title} ShowDoc</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">

--- a/Application/Home/View/Common/header.html
+++ b/Application/Home/View/Common/header.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{$title} ShowDoc</title>
+    <title>{$item.item_name} ShowDoc</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">


### PR DESCRIPTION
之前的整个项目的页面title都是showdoc，修改后在进入某个项目时将显示该项目的名称!