### PR TITLE
解决目录比较多导致的超出屏幕的目录不能查看的问题

### DIFF
--- a/Application/Home/View/Catalog/edit.html
+++ b/Application/Home/View/Catalog/edit.html
@@ -6,6 +6,10 @@
 .cat-list{
   max-height: 250px;
 }
+.cat-content{
+    max-height: 195px;
+    overflow-y: auto;
+}
 </style>
  <div id="edit-cat" class="modal hide fade">
   <!-- 编辑框 -->
@@ -50,7 +54,7 @@
     <div class="modal-header">
     <h4>{$Think.Lang.catalog_list}&nbsp;<small>({$Think.Lang.click_to_edit})</small></h4>
     </div>
-    <div id="show-cat">
+    <div id="show-cat" class="cat-content">
 
     <br>
     <br>


### PR DESCRIPTION
原来的界面：
![default](https://cloud.githubusercontent.com/assets/18900661/18196411/ce00b054-7123-11e6-9afd-e3690fe24c17.jpg)
修复后的界面：
![default](https://cloud.githubusercontent.com/assets/18900661/18196420/d65c0c30-7123-11e6-859f-04d5cca7f3e3.jpg)
