### PR TITLE
improve Dockerfile and add docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ trubo=libjpeg62-turbo-dev && \
     && docker-php-ext-install -j$(nproc) gd mcrypt  && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY ./ /var/www/html/
+COPY ./ /showdoc/
 
 RUN \
-cd /var/www/html/  && \
+rm -rf /var/www/html && ln -s /showdoc /var/www/html && \
+cd /showdoc/  && \
 cp ./Sqlite/showdoc.db.php ./showdoc.db.php && \
 chown www-data install && \
 chown -R www-data  Sqlite  Public/Uploads  Application/Runtime  server/Application/Runtime \
@@ -22,8 +23,8 @@ chown -R www-data  Sqlite  Public/Uploads  Application/Runtime  server/Applicati
  ln -s $(pwd)/startApp.sh /usr/bin/startApp.sh && \
  chmod -R  700  composer.json docker-compose.yml Dockerfile startApp.sh 
 
-VOLUME [ "/var/www/html/Sqlite","/var/www/html/install","/var/www/html/Public/Uploads" \
-	,"/var/www/html/Application/Runtime","/var/www/html/server/Application/Runtime" \
-       ,"/var/www/html/Application/Common/Conf","/var/www/html/Application/Home/Conf" ]
+VOLUME [ "/showdoc/Sqlite","/showdoc/install","/showdoc/Public/Uploads" \
+	,"/showdoc/Application/Runtime","/showdoc/server/Application/Runtime" \
+       ,"/showdoc/Application/Common/Conf","/showdoc/Application/Home/Conf" ]
 
 CMD ["startApp.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,29 @@
 FROM php:5.6-apache
-COPY ./ /var/www/html/
-
-RUN apt-get update && apt-get install -y \
+RUN \
+sed -i  's#http[:]//deb[^/ ]\+#http://ftp.cn.debian.org#g' /etc/apt/sources.list  && \
+trubo=libjpeg62-turbo-dev && \
+#trubo=libjpeg-turbo8-dev && \
+ apt-get update && apt-get install -y \
         libfreetype6-dev \
-        libjpeg62-turbo-dev \
+        $trubo  \
         libmcrypt-dev \
         libpng12-dev \
-    && docker-php-ext-install -j$(nproc) gd mcrypt
+    && docker-php-ext-install -j$(nproc) gd mcrypt  && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
+COPY ./ /var/www/html/
 
-RUN chmod -R 777 /var/www/html/
+RUN \
+cd /var/www/html/  && \
+cp ./Sqlite/showdoc.db.php ./showdoc.db.php && \
+chown www-data install && \
+chown -R www-data  Sqlite  Public/Uploads  Application/Runtime  server/Application/Runtime \
+ Application/Common/Conf/config.php  Application/Home/Conf/config.php && \
+ ln -s $(pwd)/startApp.sh /usr/bin/startApp.sh && \
+ chmod -R  700  composer.json docker-compose.yml Dockerfile startApp.sh 
 
-CMD ["apache2-foreground"]
+VOLUME [ "/var/www/html/Sqlite","/var/www/html/install","/var/www/html/Public/Uploads" \
+	,"/var/www/html/Application/Runtime","/var/www/html/server/Application/Runtime" \
+       ,"/var/www/html/Application/Common/Conf","/var/www/html/Application/Home/Conf" ]
+
+CMD ["startApp.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+server:
+  build: .
+#  extends:
+#    file: ../base-service.yml
+#    service: common
+#  command: cfrun /startApp.sh
+#  privileged: true
+#  net: host
+  ports:
+    - 4999:80
+# environment:
+#   - test=true
+  volumes:
+#    - /var/www/html/Public/Uploads
+#    - /var/www/html/Application/Common/Conf
+#    - /var/www/html/Application/Home/Conf
+#    - /var/www/html/Application/Runtime
+#    - /var/www/html/server/Application/Runtime 
+#    - /var/www/html/install 
+    - /data/volumes/showdocdb:/var/www/html/Sqlite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,13 @@ server:
 #  net: host
   ports:
     - 4999:80
-# environment:
-#   - test=true
+#  environment:
+#    - CONTEXT_PATH=/showdoc
   volumes:
-#    - /var/www/html/Public/Uploads
-#    - /var/www/html/Application/Common/Conf
-#    - /var/www/html/Application/Home/Conf
-#    - /var/www/html/Application/Runtime
-#    - /var/www/html/server/Application/Runtime 
-#    - /var/www/html/install 
-    - /data/volumes/showdocdb:/var/www/html/Sqlite
+    - /data/volumes/showdocdb:/showdoc/Sqlite
+#    - /showdoc/Public/Uploads
+#    - /showdoc/Application/Common/Conf
+#    - /showdoc/Application/Home/Conf
+#    - /showdoc/Application/Runtime
+#    - /showdoc/server/Application/Runtime 
+#    - /showdoc/install 

--- a/startApp.sh
+++ b/startApp.sh
@@ -1,19 +1,24 @@
 #!/bin/sh
-storageDir=/var/www/html/Sqlite
+storageDir=/showdoc/Sqlite
 test ! -d $storageDir && mkdir -p $storageDir
 test ! -f "$storageDir"
 #o=$(ls -ld $storageDir/showdoc.db.php | awk 'NR==1 {print $3}')
 
 if [ !  -f  $storageDir/showdoc.db.php ] ; then
-   cp /var/www/html/showdoc.db.php $storageDir/
+   cp /showdoc/showdoc.db.php $storageDir/
 fi
 
 test -z "${WWW_USER}" && WWW_USER=www-data
 if [ ! "${WWW_USER}" = "NOP" ] ; then
  echo "change owner to ${WWW_USER}"
- cd /var/www/html 
+ cd /showdoc 
  chown  ${WWW_USER} install 
  chown -R ${WWW_USER} Sqlite  Public/Uploads  Application/Runtime  server/Application/Runtime \
   Application/Common/Conf/config.php  Application/Home/Conf/config.php
+fi
+if [ -n "${CONTEXT_PATH}" ] ; then
+  if [ ! "${CONTEXT_PATH}" = "/" ]  ; then
+     rm  /var/www/html  && mkdir -p /var/www/html && ln -s /showdoc /var/www/html/${CONTEXT_PATH}
+  fi
 fi
 apache2-foreground $*

--- a/startApp.sh
+++ b/startApp.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+storageDir=/var/www/html/Sqlite
+test ! -d $storageDir && mkdir -p $storageDir
+test ! -f "$storageDir"
+#o=$(ls -ld $storageDir/showdoc.db.php | awk 'NR==1 {print $3}')
+
+if [ !  -f  $storageDir/showdoc.db.php ] ; then
+   cp /var/www/html/showdoc.db.php $storageDir/
+fi
+
+test -z "${WWW_USER}" && WWW_USER=www-data
+if [ ! "${WWW_USER}" = "NOP" ] ; then
+ echo "change owner to ${WWW_USER}"
+ cd /var/www/html 
+ chown  ${WWW_USER} install 
+ chown -R ${WWW_USER} Sqlite  Public/Uploads  Application/Runtime  server/Application/Runtime \
+  Application/Common/Conf/config.php  Application/Home/Conf/config.php
+fi
+apache2-foreground $*


### PR DESCRIPTION
## 变更说明如下：
1.  showdoc为中国区项目，默认apt-get切换为中国区镜像站点以加快镜像构建
    非中国区可注释Dockerfile中以下行或切换至更快的站点
`sed -i  's#http[:]//deb[^/ ]\+#http://ftp.cn.debian.org#g' /etc/apt/sources.list  && \`

2.  Dockerfile中调整apt-get到COPY指令以便使用docker build缓存，不用每次docker构建都重新安装依赖包

3.  权限最小化：只对需要修改资源，修改owner为 www-data

4.  增加数据卷指令，使用状态以数据卷方式保持，且镜像升级受而不影响
     
5.  增加docker-compose.yml 以便命令方式开箱即可：`docker-cmpose up -d`
   **注意文档数据默认外置于主机/data/volumes/showdocdb目录**

6. 增加startApp.sh以便在容器启用，进行一些初始化： 如showdoc.db.php不存在复制副本;修改目录权限等

7. 支持通过环境变量方式指定应用上下文(CONTEXT_PATH=/showdoc), 又方便应用以反向代理方式进行集成