### PR TITLE
安装的时候，选择语言后，提示找不到database.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 Application/Runtime/
 server/Application/Runtime/
 
+
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+.idea/
+

--- a/Application/Home/Controller/IndexController.class.php
+++ b/Application/Home/Controller/IndexController.class.php
@@ -5,7 +5,7 @@ class IndexController extends BaseController {
     public function index(){
         $tmp = @file_get_contents('./Application/Common/Conf/config.php');
         if (strstr($tmp, "showdoc not install")) {
-            header("location:./install");
+            header("location:./install/");
             exit();
         }
     	$this->checkLogin(false);


### PR DESCRIPTION
安装的时候，选择语言后，提示找不到database.php,发现是表单的相对路径问题