### PR TITLE
Update FromCommentsController.class.php

### DIFF
--- a/server/Application/Api/Controller/FromCommentsController.class.php
+++ b/server/Application/Api/Controller/FromCommentsController.class.php
@@ -20,7 +20,7 @@ class FromCommentsController extends BaseController {
             return false;
         }
 
-        $p = '/\/\*\*([\s\S])*?\*\//' ;
+        $p = "|/\*\*([\s\S]*)\*/|U";
         preg_match_all($p, $content , $matches) ;
         if ($matches && $matches[0]) {
             foreach ($matches[0] as $key => $value) {


### PR DESCRIPTION
This pattern `$p = '/\/\*\*([\s\S])*?\*\//' ;` sometimes fails with error code: PREG_JIT_STACKLIMIT_ERROR when the `$content` string is too long,  so change the pattern to `$p = "|/\*\*([\s\S]*)\*/|U";` to fix it.
