### PR TITLE
Word export style improve

### DIFF
--- a/server/Application/Api/Controller/ExportController.class.php
+++ b/server/Application/Api/Controller/ExportController.class.php
@@ -67,12 +67,12 @@ class ExportController extends BaseController {
         if ($catalogs) {
             foreach ($catalogs as $key => $value) {
                 $data .= "<h1>{$parent}、{$value['cat_name']}</h1>";
-                $data .= '<div style="margin-left:20px;">';
+                $data .= '<div style="margin-left:0px;">';
                     $child = 1 ;
                     if ($value['pages']) {
                         foreach ($value['pages'] as $page) {
                             $data .= "<h2>{$parent}.{$child}、{$page['page_title']}</h2>";
-                            $data .= '<div style="margin-left:20px;">';
+                            $data .= '<div style="margin-left:0px;">';
                                 $data .= htmlspecialchars_decode($Parsedown->text($page['page_content']));
                             $data .= '</div>';
                             $child ++;
@@ -87,7 +87,7 @@ class ExportController extends BaseController {
                                 if ($value3['pages']) {
                                     foreach ($value3['pages'] as $page3) {
                                         $data .= "<h3>{$parent}.{$parent2}.{$child2}、{$page3['page_title']}</h3>";
-                                        $data .= '<div style="margin-left:30px;">';
+                                        $data .= '<div style="margin-left:0px;">';
                                             $data .= htmlspecialchars_decode($Parsedown->text($page3['page_content']));
                                         $data .= '</div>';
                                         $child2 ++;
@@ -98,7 +98,7 @@ class ExportController extends BaseController {
                                     $parent3 = 1 ;
                                     foreach ($value3['catalogs'] as $key4 => $value4) {
                                         $data .= "<h2>{$parent}.{$parent2}.{$parent3}、{$value4['cat_name']}</h2>";
-                                        $data .= '<div style="margin-left:20px;">';
+                                        $data .= '<div style="margin-left:0px;">';
                                             $child3 = 1 ;
                                             if ($value4['pages']) {
                                                 foreach ($value4['pages'] as $page4) {

--- a/server/Application/Common/Common/function.php
+++ b/server/Application/Common/Common/function.php
@@ -66,39 +66,44 @@ function output_word($data,$fileName=''){
 
     if(empty($data)) return '';
 
-    $data = '
-        <html xmlns:v="urn:schemas-microsoft-com:vml"
-        xmlns:o="urn:schemas-microsoft-com:office:office"
-        xmlns:w="urn:schemas-microsoft-com:office:word"
-        xmlns="http://www.w3.org/TR/REC-html40">
-        <head><meta http-equiv=Content-Type content="text/html;  
-        charset=utf-8">
-        <style type="text/css">
-            table  
-            {  
-                border-collapse: collapse;
-                border: none;  
-                width: 100%;  
-            }  
-            td  
-            {  
-                border: solid #CCC 1px;  
-            }  
-            .codestyle{
-                word-break: break-all;
-                background:silver;mso-highlight:silver;
-            }
-        </style>
-        <meta name=ProgId content=Word.Document>
-        <meta name=Generator content="Microsoft Word 11">
-        <meta name=Originator content="Microsoft Word 11">
-        <xml><w:WordDocument><w:View>Print</w:View></xml></head>
-        <body>'.$data.'</body></html>';
+    $data = '<html xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office"
+    xmlns:w="urn:schemas-microsoft-com:office:word"
+    xmlns="http://www.w3.org/TR/REC-html40">
+    <head><meta http-equiv=Content-Type content="text/html; charset=utf-8">
+    <style type="text/css">
+        table  
+        {  
+            border-collapse: collapse;
+            border: none;  
+            width: 100%;  
+        }  
+        td,tr  
+        {  
+            border: solid #CCC 1px;
+            padding:3px;
+            font-size:9pt;
+        } 
+        .codestyle{
+            word-break: break-all;
+            mso-highlight:rgb(252, 252, 252);
+            padding-left: 5px; background-color: rgb(252, 252, 252); border: 1px solid rgb(225, 225, 232);
+        }
+        img {
+            width:100;
+        }
+    </style>
+    <meta name=ProgId content=Word.Document>
+    <meta name=Generator content="Microsoft Word 11">
+    <meta name=Originator content="Microsoft Word 11">
+    <xml><w:WordDocument><w:View>Print</w:View></xml></head>
+    <body>'.$data.'</body></html>';
     
     $filepath = tmpfile();
     $data = str_replace("<thead>\n<tr>","<thead><tr style='background-color: rgb(0, 136, 204); color: rgb(255, 255, 255);'>",$data);
-    $data = str_replace("<pre><code>","<table width='100%' class='codestyle'><pre><code>",$data);
+    $data = str_replace("<pre><code","<table width='100%' class='codestyle'><pre><code",$data);
     $data = str_replace("</code></pre>","</code></pre></table>",$data);
+    $data = str_replace("<img ","<img width=500 ",$data);
     $len = strlen($data);
     fwrite($filepath, $data);
     header("Content-type: application/octet-stream");


### PR DESCRIPTION
改进：
- 表格样式，border紧凑，内补丁设置3px
- 表格字体改为9pt
- 取消多级标题缩进
- 解决指定语言代码块样式不正确问题
- 图片固定宽度500

![image](https://user-images.githubusercontent.com/37329/63405747-6db0ae00-c41a-11e9-909d-a27897f58f63.png)
