### PR TITLE
修复前台任意文件上传

### DIFF
--- a/server/Application/Home/Controller/PageController.class.php
+++ b/server/Application/Home/Controller/PageController.class.php
@@ -147,7 +147,7 @@ class PageController extends BaseController {
         }else{
             $upload = new \Think\Upload();// 实例化上传类
             $upload->maxSize  = 3145728 ;// 设置附件上传大小
-            $upload->allowExts  = array('jpg', 'gif', 'png', 'jpeg');// 设置附件上传类型
+            $upload->exts  = array('jpg', 'gif', 'png', 'jpeg');// 设置附件上传类型
             $upload->rootPath = './Public/Uploads/';// 设置附件上传目录
             $upload->savePath = '';// 设置附件上传子目录
             $info = $upload->upload() ;


### PR DESCRIPTION
\server\Application\Home\Controller\PageController.class.php第150行

`$upload->allowExts  = array('jpg', 'gif', 'png', 'jpeg');// 设置附件上传类型`

$upload->allowExts 不是 Think\Upload 类的正确用法，导致文件后缀限制失效

并且方法里面没有进行$this->checkLogin();导致未登录上传文件，即前台gethell

本地起个服务器测试

上传图片，并抓包，将文件名改为`plzmyy.<>php`

![image](https://user-images.githubusercontent.com/69510679/89992134-6e8bc100-dcb7-11ea-9c12-25e63d2f8ad5.png)


![image](https://user-images.githubusercontent.com/69510679/89992189-82cfbe00-dcb7-11ea-824b-1eca381603c4.png)



生产环境下测试

![image](https://user-images.githubusercontent.com/69510679/89992259-9a0eab80-dcb7-11ea-9abc-8c379b365d7b.png)

![image](https://user-images.githubusercontent.com/69510679/89992292-a6930400-dcb7-11ea-9817-76bfecf98623.png)

修改为

`$upload->exts  = array('jpg', 'gif', 'png', 'jpeg');// 设置附件上传类型`

![image](https://user-images.githubusercontent.com/69510679/89992475-e528be80-dcb7-11ea-9bab-a7dbb6a24f6c.png)

参考链接：[RoarCTF2019 simple_upload](https://www.fuzzer.xyz/2019/10/14/RoarCTF2019%20web%20writeup/#%E8%A7%A3%E6%B3%951)