### PR TITLE
"关闭预览"修改为轻提示，避免每次进入同一个长文档都被打断操作

### DIFF
--- a/web_src/src/components/page/edit/Index.vue
+++ b/web_src/src/components/page/edit/Index.vue
@@ -389,7 +389,7 @@ export default {
       childRef.editor_unwatch()
       if (sessionStorage.getItem('page_id_unwatch_' + this.page_id)) {
       } else {
-        this.$alert(this.$t('long_page_tips'))
+        this.$message(this.$t('long_page_tips'))
         sessionStorage.setItem('page_id_unwatch_' + this.page_id, 1)
       }
     },


### PR DESCRIPTION
"关闭预览"并未提供强制打开的功能，所以这个提醒原则上为“告知”性质，提醒等级较低，以轻提示弹出即可。
每次修改一些长文档时，点击修改按钮，手已经在键盘上，弹出 alert 后，还需要将手移至鼠标关闭该提醒框，打断操作严重影响体验。