### PR TITLE
perf(CacheControl ContentType): 设置s3上传文件的字段，优化响应

### DIFF
--- a/server/Application/Api/Model/AttachmentModel.class.php
+++ b/server/Application/Api/Model/AttachmentModel.class.php
@@ -186,7 +186,12 @@ class AttachmentModel extends BaseModel
 		$resObj = $s3->putObject([
 			'Bucket' => $oss_setting['bucket'],
 			'Key'    => $oss_path,
-			'Body'   => fopen($uploadFile['tmp_name'], 'rb')
+			'Body'   => fopen($uploadFile['tmp_name'], 'rb'),
+			// 增加浏览器的缓存控制头，减缓服务器压力，增加用户体验
+			// 参考文章：https://csswizardry.com/2019/03/cache-control-for-civilians/
+			'CacheControl' => 'public, max-age=31536000, s-maxage=31536000, immutable',
+			// 设置正确的“Content-Type”响应头，避免浏览器将图片等文件当成数据流直接下载
+			'ContentType' => $uploadFile['type']
 		]);
 
 		// 不抛出异常，默认就是成功的


### PR DESCRIPTION
增加浏览器的缓存控制头；设置正确的“Content-Type”响应头
缓存控制头写法参考了文章：https://csswizardry.com/2019/03/cache-control-for-civilians/
此次修改后，文件上传成功之后
![image](https://user-images.githubusercontent.com/65681376/172753905-10c45228-208d-4a49-af6e-717647143070.png)
可以在minio的控制台可以看到正确的meta信息
![image](https://user-images.githubusercontent.com/65681376/172753970-f7ae1fb2-274d-4198-bcb9-8543d9020d59.png)
同时浏览器响应头也会产生变化
![image](https://user-images.githubusercontent.com/65681376/172754222-442f44d6-9fcb-4564-aa5b-319c079d18d4.png)

