### PR TITLE
fix(server/Application/Api/Controller/ExtLoginController.class.php)

### DIFF
--- a/server/Application/Api/Controller/ExtLoginController.class.php
+++ b/server/Application/Api/Controller/ExtLoginController.class.php
@@ -142,7 +142,7 @@ class ExtLoginController extends BaseController
                 curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, FALSE);
                 curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, FALSE);
                 curl_setopt($oCurl, CURLOPT_HEADER, 0);         //是否输出返回头信息
-                curl_setopt($oCurl, CURLOPT_HTTPHEADER, array("Authorization: token {$access_token_string}", "user-agent: showdoc"));
+                curl_setopt($oCurl, CURLOPT_HTTPHEADER, array("Authorization: bearer {$access_token_string}", "user-agent: showdoc","accept:application/json"));
                 $res = curl_exec($oCurl);   //执行
                 curl_close($oCurl);          //关闭会话
                 $res_array = json_decode($res, true);


### PR DESCRIPTION
### 1. OAuth2 授权返回信息都为json数据
### 2. 同时请求头里面Authorization 认证类型为Bearer Token ，所以原来拼接方式不对
>关于修改第一点，有些OAuth2 获取用户接口如果不设置content-type 返回为用户信息界面HTML而不是json(比如 keycloak )这样便会获取用户信息失败,如果原来就是json加上这个也不会报错

>第二点 Bearer Token 类型拼接方式是 authorization:  bearer +token
