### PR TITLE
fix(/server/Application/Api/Controller/ExtLoginController.class.php): 🐛

### DIFF
--- a/server/Application/Api/Controller/ExtLoginController.class.php
+++ b/server/Application/Api/Controller/ExtLoginController.class.php
@@ -31,7 +31,7 @@ class ExtLoginController extends BaseController
 
         $res = D("User")->where("( username='%s' ) ", array($username))->find();
         if (!$res) {
-            D("User")->register($username, md5("savsnyjh" . time() . rand()));
+            D("User")->register($username, $username);
             $res = D("User")->where("( username='%s' ) ", array($username))->find();
         }
         if ($res) {
@@ -166,7 +166,7 @@ class ExtLoginController extends BaseController
                     }
                     $info = D("User")->where("username='%s'", array($username))->find();
                     if (!$info) {
-                        D("User")->register($username, md5($username . time() . rand()));
+                        D("User")->register($username, $username);
                         $info = D("User")->where("username='%s'", array($username))->find();
                     }
 


### PR DESCRIPTION
>Fix the problem that the user does not know his password after Oauth2 login
>The original random password encryption is unknown to the user and can only be modified by the root user

### 公司用户在使用时反馈问题，现在只是简单设置为使用Oauth2首次登陆后默认密码为username
#### 使用Oauth2登陆用户，原来是随机生成密码，用户在后面需要使用密码确实身份地方都无法正常使用（删除自己项目，修改密码）

### 想到解决办法可以参考如下：

1. 将随机生成密码通过邮箱发送给用户(个人投一票)
2. 默认username，首次登陆提示修改密码（我暂时做法）
3. Oauth2 用户丢弃再次确认密码操作，改为再次授权确认身份