### PR TITLE
修复 ldap 配置为空时 htmlspecialchars_decode 报警告的问题

### DIFF
--- a/server/app/Model/User.php
+++ b/server/app/Model/User.php
@@ -588,7 +588,7 @@ class User
 
         $ldapOpen = \App\Model\Options::get('ldap_open');
         $ldapForm = \App\Model\Options::get('ldap_form');
-        $ldapForm = htmlspecialchars_decode($ldapForm);
+        $ldapForm = htmlspecialchars_decode($ldapForm ?: '');
         $ldapForm = json_decode($ldapForm, true);
 
         if (!$ldapOpen || !$ldapForm) {


### PR DESCRIPTION
部署时发现的一个问题，我部署时的 PHP 环境为 8.2.29。
复现步骤：
1. 登录时输入错误的用户名 OR 密码
2. 密码校验失败 走 LDAP 校验
3. LDAP 校验时会读取 options 表中的 `ldap_form` 配置项 的 LDAP 参数，通过 `htmlspecialchars_decode` 函数进行处理。
4. 如果 LDAP 配置项没有配置的情况下 `Options::get('ldap_form')` 函数返回的值为 NULL
5. 将 NULL 传递给 htmlspecialchars_decode  会触发警告向前端输出错误

<img width="1377" height="140" alt="image" src="https://github.com/user-attachments/assets/ba7b9a31-1131-4086-b622-d7fdafebe66e" />

解决方案：
- 通过三元运算符当  `$ldapForm` 值为 `NULL` 时，传入空字符串 而不是 `NULL`