### PR TITLE
mixed is a PHP 8+ type. In PHP 7.4.3 it is interpreted like a class type

### DIFF
--- a/server/app/Common/BaseController.php
+++ b/server/app/Common/BaseController.php
@@ -282,11 +282,11 @@ abstract class BaseController
      * @param int $status HTTP 状态码
      * @return Response
      */
-    protected function success(Response $response, mixed $data = [], int $status = 200): Response
+    protected function success(Response $response, $data = [], int $status = 200): Response
     {
         return $this->json($response, [
             'error_code' => 0,
-            'data'       => $data,
+            'data' => $data,
         ], $status);
     }
 
@@ -314,7 +314,7 @@ abstract class BaseController
         }
 
         $body = array_merge([
-            'error_code'    => $code,
+            'error_code' => $code,
             'error_message' => $message,
         ], $extra);
 


### PR DESCRIPTION
mixed is a PHP 8+ type. In PHP 7.4.3 it is interpreted like a class type, and default [] causes the fatal “class type can only be NULL”.
in composer.json it seems need compatiable with php 7.4 version, not php 8.0