### PR TITLE
修复 MCP 在多级目录路径解析中的层级计算问题

### DIFF
--- a/server/app/Mcp/Handler/PageHandler.php
+++ b/server/app/Mcp/Handler/PageHandler.php
@@ -1306,6 +1306,8 @@ MARKDOWN;
     $updateData = [];
     $pageTitle = trim($params['page_title'] ?? '');
     $pageContent = $params['page_content'] ?? null;
+    $catName = trim((string) ($params['cat_name'] ?? ''));
+    $targetCatId = (int) ($page->cat_id ?? 0);
 
     if ($pageContent !== null) {
       // 验证内容不能为空（与 PageController::save 一致）
@@ -1318,11 +1320,16 @@ MARKDOWN;
       $updateData['page_content'] = $pageContent;
     }
 
+    if ($catName !== '') {
+      $targetCatId = $this->getOrCreateCatalog($itemId, $catName);
+      $updateData['cat_id'] = $targetCatId;
+    }
+
     if ($pageTitle !== '') {
       // 检查标题是否与其他页面重复（按 item_id + cat_id + page_title 判重，允许不同目录下存在同名页面）
       $existingPage = DB::table('page')
         ->where('item_id', $itemId)
-        ->where('cat_id', $page->cat_id)
+        ->where('cat_id', $targetCatId)
         ->where('page_title', $pageTitle)
         ->where('page_id', '<>', $pageId)
         ->where('is_del', 0)
@@ -1331,6 +1338,20 @@ MARKDOWN;
         McpError::throw(McpError::OPERATION_FAILED, "页面标题已存在: {$pageTitle}");
       }
       $updateData['page_title'] = $pageTitle;
+    }
+
+    if ($pageTitle === '' && $catName !== '') {
+      // 仅改目录时，也要保证目标目录下标题不冲突
+      $existingInTargetCat = DB::table('page')
+        ->where('item_id', $itemId)
+        ->where('cat_id', $targetCatId)
+        ->where('page_title', (string) ($page->page_title ?? ''))
+        ->where('page_id', '<>', $pageId)
+        ->where('is_del', 0)
+        ->first();
+      if ($existingInTargetCat) {
+        McpError::throw(McpError::OPERATION_FAILED, '目标目录下已存在同名页面，无法移动');
+      }
     }
 
     if (empty($updateData)) {
@@ -1600,6 +1621,7 @@ MARKDOWN;
     $catNames = array_map('trim', explode('/', $catName));
     $parentCatId = 0;
     $catId = 0;
+    $depth = 0;
 
     for ($i = 0; $i < count($catNames); $i++) {
       $name = $catNames[$i];
@@ -1607,7 +1629,8 @@ MARKDOWN;
         continue;
       }
 
-      $level = $i + 2;
+      $depth++;
+      $level = $depth + 1;
 
       // 查找目录
       $catalog = DB::table('catalog')

--- a/server/app/Mcp/McpServer.php
+++ b/server/app/Mcp/McpServer.php
@@ -450,6 +450,10 @@ class McpServer
             'type' => 'string',
             'description' => '页面标题（可选）',
           ],
+          'cat_name' => [
+            'type' => 'string',
+            'description' => '目录名称（可选，传入时可将页面移动到指定目录，不存在则自动创建）',
+          ],
           'expected_hash' => [
             'type' => 'string',
             'description' => '期望的当前内容哈希（乐观锁，可选）',


### PR DESCRIPTION
# Summary
* 修复 MCP 在多级目录路径解析中的层级计算问题：getOrCreateCatalog 改为按有效目录深度计算 level，避免 A//B、//A/B 等含空段路径造成层级错位与错误建目录。
* 增强 update_page：新增可选 cat_name 支持，允许在更新页面内容/标题时同步迁移目录（目录不存在时自动创建）。
* 补充目录迁移安全校验：当仅修改目录且目标目录已存在同名页面时，返回明确错误，避免产生同目录同名冲突。
* 同步 MCP 工具定义：在 McpServer 的 update_page inputSchema 中新增 cat_name 参数说明，保证客户端与服务端能力一致。

# Why
* 之前目录层级按原始分段索引计算，遇到空段会放大层级值，导致目录树异常和目录复用失败。
* 之前 update_page 无法处理目录变更参数，导致“修改页面时不能改目录”的实际使用缺口。

# Test Plan

 使用 upsert_page 测试 cat_name=测试/A/B、测试/A//B、//测试/A/B，验证层级正确且不再错建目录。

 使用 update_page 传入 cat_name，验证页面可成功迁移到目标目录。

 在目标目录预置同名页面后再迁移，验证返回冲突错误：目标目录下已存在同名页面，无法移动。

 检查变更文件无 lint 错误。
