### PR TITLE
ci(docker): 为主镜像与发版镜像增加 linux/arm64 构建

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -29,4 +29,3 @@ jobs:
           file: Dockerfile.ARM
           platforms: |
             linux/arm/v7
-            linux/arm64

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -24,3 +24,6 @@ jobs:
           context: .
           push: true
           tags: star7th/showdoc:${{ github.event.release.tag_name }}
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,3 +26,6 @@ jobs:
           context: .
           push: true
           tags: star7th/showdoc:latest
+          platforms: |
+            linux/amd64
+            linux/arm64


### PR DESCRIPTION
webdevops/php-nginx:8.3-alpine 现已提供 linux/arm64 支持，建议：

- docker.yml / docker-release.yml：使用默认 Dockerfile 显式编译 linux/amd64 与 linux/arm64，让 64 位 ARM 设备使用完整功能镜像，减少镜像体积。
- docker-arm.yml：仅保留 linux/arm/v7（32 位 ARM 设备），因其依赖 Dockerfile.ARM 降级镜像，而 arm/v7 仍不被 webdevops 镜像支持。