### PR TITLE
🐛 fix: OpenAPI 导入数组字段未使用 example/default 占位值 (star7th/showdoc#2569)

### DIFF
--- a/server/app/Api/Controller/ImportSwaggerController.php
+++ b/server/app/Api/Controller/ImportSwaggerController.php
@@ -354,7 +354,11 @@ class ImportSwaggerController extends BaseController
         $resArray = [];
         if (isset($jsonArray['properties'])) {
             foreach ($jsonArray['properties'] as $key => $value) {
-                if (isset($value['items'])) {
+                if (array_key_exists('example', $value) || array_key_exists('default', $value)) {
+                    // 属性自带 example/default 时优先使用完整值（数组/对象/标量通用），
+                    // 避免数组字段被生成成 ["string"] 之类的 type 占位值
+                    $resArray[$key] = $this->schemaToFakeValue($value);
+                } elseif (isset($value['items'])) {
                     // 数组：递归处理 items（原始类型走末尾 else，避免出现 [[]]）
                     $resArray[$key] = [$this->toB($value['items'], $depth + 1)];
                 } elseif (isset($value['properties'])) {

--- a/server/tests/ImportSwaggerTest.php
+++ b/server/tests/ImportSwaggerTest.php
@@ -574,6 +574,49 @@ class ImportSwaggerTest extends TestCase
     // ===============================================================
 
     /**
+     * 回归测试：toB 生成示例 JSON 时，数组/对象字段应优先使用字段自身的
+     * example/default，而不是用 type 占位值（如 ["string"] / [[]]）。
+     * 对应官方 issue #2569。
+     */
+    public function testToBArrayExamplePreference(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'baseDate' => [
+                    'type' => 'string',
+                    'example' => '2026-07-28',
+                    'default' => '2026-07-28',
+                ],
+                'countryCode' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'example' => ['DE'],
+                    'default' => ['DE'],
+                ],
+                'bikeSeries' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'example' => ['AGO'],
+                ],
+                'emptyList' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'example' => [],
+                    'default' => [],
+                ],
+            ],
+        ];
+
+        $result = $this->invokeMethod('toB', [$schema]);
+
+        $this->assertEquals('2026-07-28', $result['baseDate'] ?? null);
+        $this->assertEquals(['DE'], $result['countryCode'] ?? null, 'array field should use its example');
+        $this->assertEquals(['AGO'], $result['bikeSeries'] ?? null, 'array field should use its example');
+        $this->assertEquals([], $result['emptyList'] ?? null, 'empty array example should be preserved');
+    }
+
+    /**
      * 直接测试 definitionToJsonArray — 基本属性提取
      */
     public function testDefinitionToJsonArrayBasic(): void


### PR DESCRIPTION
Fixes star7th/showdoc#2569

## 问题

OpenAPI 3 导入时，requestBody 示例的数组字段（如 `countryCode`）忽略了 schema 属性自带的 `example`/`default`，被生成为 type 占位值（`["string"]`），导致示例失真。

## 修复

`ImportSwaggerController::toB()` 中，属性自带 `example`/`default` 时优先使用完整值（数组/对象/标量通用），否则才按 `items`/`properties` 递归生成。

## 测试

新增回归测试 `testToBArrayExamplePreference`（含空数组 example 保真），`ImportSwaggerTest` 36→37 全过。